### PR TITLE
Adjustments to `MusicService` auth flow

### DIFF
--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -111,7 +111,6 @@ def parse_response(service, response, search_type):
         service,
         search_type,
     )
-
     items = []
     # The result to be parsed is in either searchResult or getMetadataResult
     if "searchResult" in response:

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -61,7 +61,6 @@ from urllib.parse import quote as quote_url
 import logging
 from collections import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
-from ..exceptions import MusicServiceAuthException
 from ..utils import camel_to_underscore
 
 
@@ -112,13 +111,6 @@ def parse_response(service, response, search_type):
         service,
         search_type,
     )
-    if "faultcode" in response:
-        raise MusicServiceAuthException(
-            "{}: {}".format(
-                response["faultcode"],
-                response.get("faultstring"),
-            )
-        )
 
     items = []
     # The result to be parsed is in either searchResult or getMetadataResult

--- a/soco/music_services/data_structures.py
+++ b/soco/music_services/data_structures.py
@@ -61,6 +61,7 @@ from urllib.parse import quote as quote_url
 import logging
 from collections import OrderedDict
 from ..data_structures import DidlResource, DidlItem, SearchResult
+from ..exceptions import MusicServiceAuthException
 from ..utils import camel_to_underscore
 
 
@@ -111,6 +112,14 @@ def parse_response(service, response, search_type):
         service,
         search_type,
     )
+    if "faultcode" in response:
+        raise MusicServiceAuthException(
+            "{}: {}".format(
+                response["faultcode"],
+                response.get("faultstring"),
+            )
+        )
+
     items = []
     # The result to be parsed is in either searchResult or getMetadataResult
     if "searchResult" in response:

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -762,7 +762,11 @@ class MusicService:
             str: Registration URL used for service linking.
 
         """
-        reg_url, self.link_code, self.link_device_id =  self.soap_client.device_or_app_link_auth_part1()
+        (
+            reg_url,
+            self.link_code,
+            self.link_device_id,
+        ) = self.soap_client.device_or_app_link_auth_part1()
         return reg_url
 
     def device_or_app_link_auth_part2(self, link_code=None, link_device_id=None):

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -227,12 +227,8 @@ class MusicServiceSoapClient:
                 #     <ms:privateKey>yyyyyy</ms:privateKey>
                 #   </ms:RefreshAuthTokenResult>
                 # </detail>
-                auth_token = exc.detail.find(
-                    ".//xmlns:authToken", {"xmlns": self.namespace}
-                ).text
-                private_key = exc.detail.find(
-                    ".//xmlns:privateKey", {"xmlns": self.namespace}
-                ).text
+                auth_token = exc.detail.findtext(".//authToken")
+                private_key = exc.detail.findtext(".//privateKey")
 
                 # Create new token pair and save it
                 token_pair = (auth_token, private_key)

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -30,6 +30,7 @@ import logging
 from urllib.parse import quote as quote_url
 import json
 import requests
+import time
 from xmltodict import parse
 
 from .. import discovery
@@ -115,7 +116,7 @@ class MusicServiceSoapClient:
 
         # According to the SONOS SMAPI, this header must be sent with all
         # SOAP requests. Building this is an expensive operation (though
-        # occasionally necessary), so f we have a cached value, return it
+        # occasionally necessary), so if we have a cached value, return it
         if self._cached_soap_header is not None:
             return self._cached_soap_header
         music_service = self.music_service
@@ -130,12 +131,11 @@ class MusicServiceSoapClient:
             context = XML.Element("context")
             # Add timezone offset e.g. "+01:00"
             timezone = XML.SubElement(context, "timezone")
-            # FIXME this could be re-enabled once it has received more testing
-            # offset = (
-            #     time.timezone if (time.localtime().tm_isdst == 0) else time.altzone
-            # ) * -1
-            # hours, minutes = offset / 3600, (offset % 3600) / 60
-            timezone.text = "+01:00"  # "{:0=+3.0f}:{:0>2.0f}".format(hours, minutes)
+            offset = (
+                time.timezone if (time.localtime().tm_isdst == 0) else time.altzone
+            ) * -1
+            hours, minutes = offset / 3600, (offset % 3600) / 60
+            timezone.text = "{:0=+3.0f}:{:0>2.0f}".format(hours, minutes)
             credentials_header.append(context)
 
             login_token = XML.Element("loginToken")
@@ -276,41 +276,43 @@ class MusicServiceSoapClient:
         See `MusicService.device_or_app_link_auth_part1` for details
 
         """
-        print(self.music_service.auth_type)
+        link_device_id = None
+
         if self.music_service.auth_type == "DeviceLink":
-            log.info("Perform DeviceLink auth part 1")
+            log.debug("Perform DeviceLink auth part 1")
             result = self.call(
                 "getDeviceLinkCode", [("householdId", self._household_id)]
             )["getDeviceLinkCodeResult"]
-            link_device_id = None
             if "linkDeviceId" in result:
                 link_device_id = result["linkDeviceId"]
             return result["regUrl"], result["linkCode"], link_device_id
         elif self.music_service.auth_type == "AppLink":
-            log.info("Perform AppLink auth part 1")
+            log.debug("Perform AppLink auth part 1")
             result = self.call("getAppLink", [("householdId", self._household_id)])[
                 "getAppLinkResult"
             ]
             auth_parts = result["authorizeAccount"]["deviceLink"]
-            return auth_parts["regUrl"], auth_parts["linkCode"], None
+            if "linkDeviceId" in auth_parts:
+                link_device_id = auth_parts["linkDeviceId"]
+            return auth_parts["regUrl"], auth_parts["linkCode"], link_device_id
         raise MusicServiceAuthException(
             "device_or_app_link_auth_part1 is not implemented "
             "for auth type {}".format(self.music_service.auth_type)
         )
 
-    def device_or_app_link_auth_part2(self, link_code):
+    def device_or_app_link_auth_part2(self, link_code, link_device_id=None):
         """Perform part 2 of a Device or App Link authentication session
 
         See `MusicService.device_or_app_link_auth_part2` for details
 
         """
-        log.info("Perform DeviceLink or AppLink auth part 2")
+        log.debug("Perform DeviceLink or AppLink auth part 2")
         result = self.call(
             "getDeviceAuthToken",
             [
                 ("householdId", self._household_id),
                 ("linkCode", link_code),
-                ("linkDeviceId", self._device_id),
+                ("linkDeviceId", link_device_id or self._device_id),
             ],
         )["getDeviceAuthTokenResult"]
         token_pair = (result["authToken"], result["privateKey"])
@@ -450,6 +452,10 @@ class MusicService:
         self.manifest_data = None
         self._search_prefix_map = None
         self.service_type = data["ServiceType"]
+
+        # Cached values used between part1 and part2
+        self.link_code = None
+        self.link_device_id = None
 
         self.soap_client = MusicServiceSoapClient(
             endpoint=self.secure_uri,
@@ -743,21 +749,26 @@ class MusicService:
         """Perform part 1 of a device link authentication session
 
         Returns:
-            tuple: Returns device link authentication information tuple on the
-            form: (registration_URL, link_code, device_id)
+            str: Registration URL used for service linking.
 
         """
+        reg_url, self.link_code, self.link_device_id =  self.soap_client.device_or_app_link_auth_part1()
+        return reg_url
 
-        return self.soap_client.device_or_app_link_auth_part1()
-
-    def device_or_app_link_auth_part2(self, linkcode):
+    def device_or_app_link_auth_part2(self, link_code=None, link_device_id=None):
         """Perform part 2 of the device link authentication session
 
         Args:
-            linkcode (str): The link code returned in part1
+            link_code (str, optional): A link code generated from part1.
+                If not provided, cached code from part1 will be used.
+            link_device_id (str, optional): A link device ID generated from part1.
+                If not provided, cached device ID from part1 will be used.
 
         """
-        return self.soap_client.device_or_app_link_auth_part2(linkcode)
+        _link_code = link_code or self.link_code
+        _link_device_id = link_device_id or self.link_device_id
+        self.soap_client.device_or_app_link_auth_part2(_link_code, _link_device_id)
+        self.link_code = self.link_device_id = None
 
     ########################################################################
     #                                                                      #

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -196,9 +196,19 @@ class MusicServiceSoapClient:
         try:
             result_elt = message.call()
         except SoapFault as exc:
+            if "Client.AuthTokenExpired" in exc.faultcode:
+                raise MusicServiceAuthException(
+                    "Authorization for {} expired or invalid: [{} / {} / {}]".format(
+                        self.music_service.service_name,
+                        exc.faultcode,
+                        exc.faultstring,
+                        exc.detail,
+                    )
+                ) from exc
+
             if "Client.TokenRefreshRequired" in exc.faultcode:
-                log.info(
-                    "Auth token for %s expired. Attempt to refresh.",
+                log.debug(
+                    "Auth token for %s expired, attempting to refresh",
                     self.music_service.service_name,
                 )
                 if self.music_service.auth_type not in ("DeviceLink", "AppLink"):

--- a/soco/music_services/music_service.py
+++ b/soco/music_services/music_service.py
@@ -643,7 +643,7 @@ class MusicService:
         if self.presentation_map_uri is None:
             # Assume not searchable?
             return self._search_prefix_map
-        log.info("Fetching presentation map from %s", self.presentation_map_uri)
+        log.debug("Fetching presentation map from %s", self.presentation_map_uri)
         pmap = requests.get(self.presentation_map_uri, timeout=9)
         pmap_root = XML.fromstring(pmap.content)
         # Search translations can appear in Category or CustomCategory elements

--- a/soco/soap.py
+++ b/soco/soap.py
@@ -300,6 +300,13 @@ class SoapMessage:
         if status == 200:
             # The response is good. Extract the Body
             tree = XML.fromstring(response.content)
+            # Check for faults in the content
+            fault = tree.find(".//{http://schemas.xmlsoap.org/soap/envelope/}Fault")
+            if fault:
+                faultcode = fault.findtext("faultcode")
+                faultstring = fault.findtext("faultstring")
+                faultdetail = fault.find("detail")
+                raise SoapFault(faultcode, faultstring, faultdetail)
             # Get the first child of the <Body> tag. NB There should only be
             # one if the RPC standard is followed.
             body = tree.find("{http://schemas.xmlsoap.org/soap/envelope/}Body")[0]


### PR DESCRIPTION
Includes the following:
* Adds `linkDeviceId` handling into AppLink flows.
* Simplifies the `part1`/`part2` handling by caching values instead of passing back tuples. These can still be accessed as the `link_code` and `link_code_id` attributes on the `MusicService` instance and passed into `part2`. This may be necessary if the `MusicService` instance is not preserved between steps.
* Handles more authorization failure conditions.
* Uncomment the timezone handling.
* Reduce unnecessary log levels, fix typos.

Here's how auth can be done now:
```
>>> from soco.music_services.music_service import MusicService
>>> plex = MusicService("Plex")
>>> reg_url = plex.device_or_app_link_auth_part1()

 -> Go complete authentication

>>> plex.device_or_app_link_auth_part2()
>>> for result in plex.search("artists", "Stevie Wonder"):
...     result
...
<soco.music_services.data_structures.MSArtist object at 0x7f8b5b1bf3d0>
```

If the `MusicService` instance is lost during auth, this can be done instead:
```
>>> from soco.music_services.music_service import MusicService
>>> plex = MusicService("Plex")
>>> reg_url = plex.device_or_app_link_auth_part1()
>>> print(plex.link_code, plex.link_code_id)  # Save for later

 -> Go complete authentication

>>> from soco.music_services.music_service import MusicService
>>> plex = MusicService("Plex")
>>> plex.device_or_app_link_auth_part2(link_code=link_code, link_code_id=link_code_id)
```